### PR TITLE
Finished adding option to assert all 1d time-var variables are metadata

### DIFF
--- a/docs/source/manual.rst
+++ b/docs/source/manual.rst
@@ -297,6 +297,11 @@ The arguments to the ``s2smake`` utility are as follows.
 -  ``--metadata VNAME`` (``-m VNAME``):  Indicate that the variable ``VNAME`` should
    be treated as metadata, and written to all output files.  There may be more than
    one ``--metadata`` (or ``-m``) options given, each one being added to a list.
+
+-  ``--meta1d`` (``-1``):  This flag forces all 1D time-variant variables to be treated
+   as metadata.  These variables need not be added explicitly to the list of metadata
+   variables (i.e., with the ``--metadata`` or ``-m`` argument).  These variables will
+   be added to the list when the PyReshaper runs.
    
 -  ``--specfile SPECFILE`` (``-o SPECFILE``):  The name of the *specfile* to write,
    containing the specification of the PyReshaper job.  The default *specfile* name
@@ -449,6 +454,11 @@ can include the full, absolute path information for the output
    as time-series variables (i.e., treated as metadata), since all 
    time-invariant (time-independent) variables will be treat as metadata
    automatically.
+
+-  ``assume_1d_time_variant_metadata``: If set to ``True``, this indicates
+   that all 1D time-variant variables (i.e., variables that *only* depend
+   upon ``time``) should be added to the list of ``time_variant_metadata``
+   when the Reshaper runs.  The default for this option is ``False``.
 
 -  ``backend``: This specifies which I/O backend to use for reading
    and writing NetCDF files.  The default backend is ``'netCDF4'``, but

--- a/scripts/s2smake
+++ b/scripts/s2smake
@@ -27,6 +27,9 @@ def cli(argv=None):
               options and write the Specifier to a named file."""
 
     parser = optparse.OptionParser(prog='s2smake', description=desc)
+    parser.add_option('-1', '--meta1d', default=False, action='store_true',
+                      help=("Treat all 1D time-variant variables as metadata "
+                            "variables"))
     parser.add_option('-b', '--backend', default='netCDF4', type='string',
                       help=("I/O backend to be used when reading or writing "
                             "from NetCDF files ('Nio' or 'netCDF4')"))
@@ -69,7 +72,7 @@ def cli(argv=None):
     if opts.netcdf_format not in ['netcdf', 'netcdf4', 'netcdf4c']:
         raise ValueError(("Unacceptable NetCDF format "
                           "{0}".format(opts.netcdf_format)))
-    
+
     # Check the I/O backend name
     if opts.backend not in ['Nio', 'netCDF4']:
         raise ValueError(("Unacceptable NetCDF backend name "
@@ -99,6 +102,7 @@ def main(argv=None):
     spec.output_file_prefix = opts.output_prefix
     spec.output_file_suffix = opts.output_suffix
     spec.time_variant_metadata = opts.metadata
+    spec.assume_1d_time_variant_metadata = opts.meta1d
 
     # Validate before saving
     spec.validate()

--- a/source/pyreshaper/reshaper.py
+++ b/source/pyreshaper/reshaper.py
@@ -212,7 +212,7 @@ class Reshaper(object):
         self._timer.start('Initializing Simple Communicator')
         if simplecomm is None:
             simplecomm = create_comm(serial=serial)
-            
+
         # Reference to the simple communicator
         self._simplecomm = simplecomm
         self._timer.stop('Initializing Simple Communicator')
@@ -249,6 +249,9 @@ class Reshaper(object):
 
         # Store the list of metadata names
         self._metadata_names = specifier.time_variant_metadata
+
+        # Store whether to treat 1D time-variant variables as metadata
+        self._1d_metadata = specifier.assume_1d_time_variant_metadata
 
         # Store the output file prefix and suffix
         self._output_prefix = specifier.output_file_prefix
@@ -312,6 +315,8 @@ class Reshaper(object):
             if self._unlimited_dim not in var.dimensions:
                 self._time_invariant_metadata.append(var_name)
             elif var_name in self._metadata_names:
+                self._time_variant_metadata.append(var_name)
+            elif self._1d_metadata and len(var.dimensions) == 1:
                 self._time_variant_metadata.append(var_name)
             else:
                 all_tsvars[var_name] = var.datatype.itemsize * var.size
@@ -623,7 +628,7 @@ class Reshaper(object):
                 remove(temp_filename)
             if self._write_mode == 'a' and out_name in self._existing:
                 rename(out_filename, temp_filename)
-                out_file = iobackend.NCFile(temp_filename, 'a', 
+                out_file = iobackend.NCFile(temp_filename, 'a',
                                             self._netcdf_format,
                                             self._netcdf_compression)
                 appending = True

--- a/source/pyreshaper/specification.py
+++ b/source/pyreshaper/specification.py
@@ -51,6 +51,7 @@ class Specifier(object):
                  prefix='tseries.',
                  suffix='.nc',
                  metadata=[],
+                 meta1d=False,
                  backend='netCDF4',
                  **kwargs):
         """
@@ -76,6 +77,10 @@ class Specifier(object):
             metadata (list): List of variable names specifying the
                 variables that should be included in every
                 time-series output file
+            meta1d (bool): True if 1D time-variant variables should
+                be treated as metadata variables, False otherwise.
+            backend (str): Which I/O backend to use ('Nio' for
+                PyNIO, 'netCDF4' for netCDF4-python)
             kwargs (dict): Optional arguments describing the
                 Reshaper run
         """
@@ -97,9 +102,11 @@ class Specifier(object):
         #  prefix + variable_name + suffix)
         self.output_file_suffix = suffix
 
-        # List of time-variant variables that should be included in all
-        #  output files.
+        # List of time-variant variables that should be included in all output files.
         self.time_variant_metadata = metadata
+
+        # Whether all 1D time-variant variables should be treated as metadata
+        self.assume_1d_time_variant_metadata = meta1d
 
         # Store the netCDF I/O backend name
         self.io_backend = backend
@@ -164,9 +171,14 @@ class Specifier(object):
         # Validate the type of each time-variant metadata variable name
         for var_name in self.time_variant_metadata:
             if not isinstance(var_name, str):
-                err_msg = "Time-variant metadata variable names must be " + \
-                          "given as strings"
+                err_msg = ("Time-variant metadata variable names must be "
+                           "given as strings")
                 raise TypeError(err_msg)
+
+        # Validate the type of assume_1d_time_variant_metadata
+        if not isinstance(self.assume_1d_time_variant_metadata, bool):
+            err_msg = "Flag to assume 1D time-variant metadata must be boolean"
+            raise TypeError(err_msg)
 
         # Validate the type of the backend
         if not isinstance(self.io_backend, str):

--- a/source/pyreshaper/test/mkTestData.py
+++ b/source/pyreshaper/test/mkTestData.py
@@ -108,6 +108,9 @@ def check_outfile(infiles, prefix, tsvar, suffix, metadata, once, **kwds):
         return assertions
     ncout = Nio.open_file(outfile, 'r')
 
+    if 'meta1d' in kwds and kwds['meta1d'] is True:
+        metadata.append('time')
+
     series_step = 0
     for infile in infiles:
         _assert('{0!r} exists'.format(infile), os.path.exists(infile))

--- a/source/pyreshaper/test/s2smakeTests.py
+++ b/source/pyreshaper/test/s2smakeTests.py
@@ -41,6 +41,8 @@ class s2smakeTest(unittest.TestCase):
                          'Default output suffix is not ".nc"')
         self.assertEqual(opts.specfile, 'input.s2s',
                          'Default output suffix is not ".nc"')
+        self.assertEqual(opts.meta1d, False,
+                         'Default 1D metadata flag is not False')
 
     def test_CLI_set_all_short(self):
         clevel = 3
@@ -51,7 +53,8 @@ class s2smakeTest(unittest.TestCase):
         suffix = '.suffix'
         infiles = ['s2smakeTests.py', 'specificationTests.py']
 
-        argv = ['-c', str(clevel), '-f', ncfmt]
+        argv = ['-1']
+        argv.extend(['-c', str(clevel), '-f', ncfmt])
         for md in metadata:
             argv.extend(['-m', md])
         argv.extend(['-o', specfile, '-p', prefix, '-s', suffix])
@@ -79,6 +82,8 @@ class s2smakeTest(unittest.TestCase):
                          'Default output suffix is not {0!r}'.format(suffix))
         self.assertEqual(opts.specfile, specfile,
                          'Default output suffix is not {0!r}'.format(specfile))
+        self.assertEqual(opts.meta1d, True,
+                         'Default 1D metadata flag is not False')
 
     def test_CLI_set_all_long(self):
         clevel = 3
@@ -89,7 +94,8 @@ class s2smakeTest(unittest.TestCase):
         suffix = '.suffix'
         infiles = ['s2smakeTests.py', 'specificationTests.py']
 
-        argv = ['--compression_level', str(clevel), '--netcdf_format', ncfmt]
+        argv = ['--meta1d']
+        argv.extend(['--compression_level', str(clevel), '--netcdf_format', ncfmt])
         for md in metadata:
             argv.extend(['--metadata', md])
         argv.extend(['--specfile', specfile, '--output_prefix', prefix,
@@ -115,6 +121,8 @@ class s2smakeTest(unittest.TestCase):
                          'Default output suffix is not {0!r}'.format(suffix))
         self.assertEqual(opts.specfile, specfile,
                          'Default output suffix is not {0!r}'.format(specfile))
+        self.assertEqual(opts.meta1d, True,
+                         'Default 1D metadata flag is not False')
 
     def test_main_defaults(self):
         argv = ['s2smakeTests.py']
@@ -142,6 +150,8 @@ class s2smakeTest(unittest.TestCase):
                          'Default output prefix is not "tseries."')
         self.assertEqual(spec.output_file_suffix, '.nc',
                          'Default output suffix is not ".nc"')
+        self.assertEqual(spec.assume_1d_time_variant_metadata, False,
+                         'Default 1D time-variant metadata flag is not False')
 
     def test_main_set_all_short(self):
         clevel = 3
@@ -152,7 +162,7 @@ class s2smakeTest(unittest.TestCase):
         suffix = '.suffix'
         infiles = ['s2smakeTests.py', 'specificationTests.py']
 
-        argv = ['-c', str(clevel), '-f', ncfmt]
+        argv = ['-1', '-c', str(clevel), '-f', ncfmt]
         for md in metadata:
             argv.extend(['-m', md])
         argv.extend(['-o', specfile, '-p', prefix, '-s', suffix])
@@ -186,6 +196,8 @@ class s2smakeTest(unittest.TestCase):
                          'Default output prefix is not {0!r}'.format(prefix))
         self.assertEqual(spec.output_file_suffix, suffix + '.nc',
                          'Default output suffix is not {0!r}'.format(suffix))
+        self.assertEqual(spec.assume_1d_time_variant_metadata, True,
+                         'Default 1D time-variant metadata flag is not True')
 
     def test_main_set_all_long(self):
         clevel = 3
@@ -196,7 +208,7 @@ class s2smakeTest(unittest.TestCase):
         suffix = '.suffix'
         infiles = ['s2smakeTests.py', 'specificationTests.py']
 
-        argv = ['--compression_level', str(clevel), '--netcdf_format', ncfmt]
+        argv = ['--meta1d', '--compression_level', str(clevel), '--netcdf_format', ncfmt]
         for md in metadata:
             argv.extend(['--metadata', md])
         argv.extend(['--specfile', specfile, '--output_prefix', prefix,
@@ -231,6 +243,8 @@ class s2smakeTest(unittest.TestCase):
                          'Default output prefix is not {0!r}'.format(prefix))
         self.assertEqual(spec.output_file_suffix, suffix + '.nc',
                          'Default output suffix is not {0!r}'.format(suffix))
+        self.assertEqual(spec.assume_1d_time_variant_metadata, True,
+                         'Default 1D time-variant metadata flag is not True')
 
 if __name__ == "__main__":
     unittest.main()

--- a/source/pyreshaper/test/specificationTests.py
+++ b/source/pyreshaper/test/specificationTests.py
@@ -44,10 +44,11 @@ class SpecifierTests(unittest.TestCase):
         prefix = 'pre.'
         suffix = '.suf.nc'
         metadata = ['x', 'y', 'z']
+        meta1d = True
         backend = 'Nio'
         spec = specification.Specifier(
             infiles=in_list, ncfmt=fmt, compression=cl, prefix=prefix,
-            suffix=suffix, metadata=metadata, backend=backend)
+            suffix=suffix, metadata=metadata, meta1d=meta1d, backend=backend)
         for i1, i2 in zip(spec.input_file_list, in_list):
             self.assertEqual(i1, i2,
                              'Input file list not initialized properly')
@@ -61,9 +62,11 @@ class SpecifierTests(unittest.TestCase):
                          'Output file prefix not initialized properly')
         self.assertEqual(spec.output_file_suffix, suffix,
                          'Output file prefix not initialized properly')
-        for i1,i2 in zip(spec.time_variant_metadata, metadata):
+        for i1, i2 in zip(spec.time_variant_metadata, metadata):
             self.assertEqual(i1, i2,
                              'Time variant metadata list not initialized properly')
+        self.assertEqual(spec.assume_1d_time_variant_metadata, meta1d,
+                         '1D metadata flag not initialized properly')
 
     def test_validate_types(self):
         in_list = ['a', 'b', 'c']
@@ -162,6 +165,19 @@ class SpecifierTests(unittest.TestCase):
             suffix=suffix, metadata=metadata)
         self.assertRaises(TypeError, spec.validate_types)
 
+    def test_validate_types_fail_meta1d(self):
+        in_list = ['a', 'b', 'c']
+        fmt = 'netcdf'
+        cl = 5
+        prefix = 'pre.'
+        suffix = '.suf.nc'
+        metadata = ['x', 'y', 'z']
+        meta1d = 't'
+        spec = specification.Specifier(
+            infiles=in_list, ncfmt=fmt, compression=cl, prefix=prefix,
+            suffix=suffix, meta1d=meta1d, metadata=metadata)
+        self.assertRaises(TypeError, spec.validate_types)
+
     def test_validate_values_fail_input(self):
         in_list = ['a', 'b', 'c']
         fmt = 'netcdf'
@@ -255,7 +271,7 @@ class SpecifierTests(unittest.TestCase):
         spec.write(fname)
         self.assertTrue(os.path.exists(fname), 'Specfile failed to write')
         spec2 = pickle.load(open(fname, 'r'))
-        for i1,i2 in zip(spec2.input_file_list, in_list):
+        for i1, i2 in zip(spec2.input_file_list, in_list):
             self.assertEqual(i1, i2,
                              'Input file list not initialized properly')
         self.assertEqual(spec2.netcdf_format, fmt,
@@ -266,7 +282,7 @@ class SpecifierTests(unittest.TestCase):
                          'Output file prefix not initialized properly')
         self.assertEqual(spec2.output_file_suffix, suffix,
                          'Output file prefix not initialized properly')
-        for i1,i2 in zip(spec2.time_variant_metadata, metadata):
+        for i1, i2 in zip(spec2.time_variant_metadata, metadata):
             self.assertEqual(i1, i2,
                              'Time variant metadata list not initialized properly')
         os.remove(fname)


### PR DESCRIPTION
This feature can be enabled through the command-line tool with the '-1' or '--meta1d' options to 's2smake'.  Alternately, 'meta1d=True' option can be set in the 'create_specifier' function, or the 'assume_1d_time_variant_metadata' attribute of the Specifier can be set to True.