### PR TITLE
Pin commit hash for 3rd party actions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: pre-commit/action@0764670bf370aab253130d534e1eda7ff497dc60 #v2.0.0
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd #v3.0.1

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@0764670bf370aab253130d534e1eda7ff497dc60 #v2.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache conda
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           # Increase this value to reset cache if ci/environment.yml has not changed
           CACHE_NUMBER: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/environment.yml') }}
       - name: Setup miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@11ae174708d1ae769b9457e7d6ed64d606c99af1 #v2
         with:
           activate-environment: pyreshaper # Defined in ci/environment.yml
           auto-update-conda: false
@@ -52,7 +52,7 @@ jobs:
       - name: Run Tests
         run: ci/runtests.sh
       - name: Upload code coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@e3f7b8baf8199f0945b1a1a79d355e4f22c53e4f#v1
         with:
           file: ./coverage.xml
           flags: unittests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run Tests
         run: ci/runtests.sh
       - name: Upload code coverage to Codecov
-        uses: codecov/codecov-action@e3f7b8baf8199f0945b1a1a79d355e4f22c53e4f#v1
+        uses: codecov/codecov-action@e3f7b8baf8199f0945b1a1a79d355e4f22c53e4f #v1
         with:
           file: ./coverage.xml
           flags: unittests


### PR DESCRIPTION
Pinning commit hashes per new NCAR guidance on GitHub repo whitelisting. 

I was tagged in this repository despite not being involved with it. @sherimickelson do you have any insight? Should we archive the repository? I am not going to fix the tokens/secrets issues that are now arising.

Same thing for https://github.com/NCAR/PyConform/pull/110 and https://github.com/NCAR/pyAverager/pull/61